### PR TITLE
Add SCSS information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@
 1. Go into your WP admin backend 
 1. Go to "Appearance -> Themes"
 1. Activate the UnderStrap Child theme
+
+## CSS Compilers
+This site now uses SCSS which can be found in `/sass/*` and is compiled to `/css/child-theme.css`.
+
+To compile your sass, navigate to the theme directory and run 'gulp sass'. Alternatively, use `gulp watch` to compile on 
+file save and `gulp watch-bs` for browser-sync (this works well with localhost development, but may need alterations for 
+virtual machines, docker).


### PR DESCRIPTION
Add stub entry for SASS information to README.md of the child theme. This includes information on compiling.